### PR TITLE
Preservar directorios al convertir RAR a ZIP

### DIFF
--- a/test_conversion.py
+++ b/test_conversion.py
@@ -9,6 +9,8 @@ import tempfile
 import shutil
 from pathlib import Path
 
+from rar_to_zip_converter import convert_rar_to_zip_file
+
 def create_test_rar():
     """Crear un archivo de prueba para simular RAR (en realidad creamos un ZIP temporal)"""
     test_dir = tempfile.mkdtemp()
@@ -16,28 +18,37 @@ def create_test_rar():
     # Crear algunos archivos de prueba
     test_files = [
         "archivo1.txt",
-        "archivo2.txt", 
+        "archivo2.txt",
         "carpeta/archivo3.txt",
-        "carpeta/subcarpeta/archivo4.txt"
+        "carpeta/subcarpeta/archivo4.txt",
     ]
-    
+
     for file_path in test_files:
         full_path = os.path.join(test_dir, file_path)
         os.makedirs(os.path.dirname(full_path), exist_ok=True)
-        
-        with open(full_path, 'w', encoding='utf-8') as f:
+
+        with open(full_path, "w", encoding="utf-8") as f:
             f.write(f"Contenido de {file_path}\n")
             f.write("Este es un archivo de prueba para el conversor RAR a ZIP.\n")
-    
+
+    # Crear un directorio vacío
+    empty_dir = os.path.join(test_dir, "carpeta_vacia")
+    os.makedirs(empty_dir, exist_ok=True)
+
     # Crear archivo ZIP temporal (simulando RAR)
-    temp_rar = tempfile.NamedTemporaryFile(suffix='.rar', delete=False)
+    temp_rar = tempfile.NamedTemporaryFile(suffix=".rar", delete=False)
     temp_rar.close()
-    
-    with zipfile.ZipFile(temp_rar.name, 'w', zipfile.ZIP_DEFLATED) as zf:
+
+    with zipfile.ZipFile(temp_rar.name, "w", zipfile.ZIP_DEFLATED) as zf:
         for root, dirs, files in os.walk(test_dir):
+            rel_root = os.path.relpath(root, test_dir)
+            if rel_root == ".":
+                rel_root = ""
+            if not files and not dirs:
+                zf.writestr(rel_root + "/", b"")
             for file in files:
                 file_path = os.path.join(root, file)
-                arcname = os.path.relpath(file_path, test_dir)
+                arcname = os.path.join(rel_root, file)
                 zf.write(file_path, arcname)
     
     # Limpiar directorio temporal
@@ -49,44 +60,20 @@ def test_conversion():
     """Probar la conversión RAR a ZIP"""
     print("🧪 Iniciando pruebas del conversor RAR a ZIP...")
     
-    try:
-        # Crear archivo de prueba
-        print("📁 Creando archivo de prueba...")
-        test_rar = create_test_rar()
-        print(f"✅ Archivo de prueba creado: {test_rar}")
-        
-        # Simular conversión (en realidad solo copiamos el contenido)
-        test_zip = test_rar.replace('.rar', '.zip')
-        
-        print("🔄 Simulando conversión...")
-        with zipfile.ZipFile(test_rar, 'r') as rar_file:
-            with zipfile.ZipFile(test_zip, 'w', zipfile.ZIP_DEFLATED) as zip_file:
-                for file_info in rar_file.filelist:
-                    file_data = rar_file.read(file_info.filename)
-                    zip_file.writestr(file_info.filename, file_data)
-        
-        print(f"✅ Archivo ZIP creado: {test_zip}")
-        
-        # Verificar contenido
-        print("🔍 Verificando contenido...")
-        with zipfile.ZipFile(test_zip, 'r') as zip_file:
-            file_list = zip_file.namelist()
-            print(f"📋 Archivos en el ZIP: {len(file_list)}")
-            for file_name in file_list:
-                print(f"   - {file_name}")
-        
-        # Limpiar archivos temporales
-        os.unlink(test_rar)
-        os.unlink(test_zip)
-        
-        print("🎉 ¡Todas las pruebas pasaron exitosamente!")
-        print("✅ El conversor está funcionando correctamente")
-        
-    except Exception as e:
-        print(f"❌ Error durante las pruebas: {e}")
-        return False
-    
-    return True
+    # Crear archivo de prueba
+    test_rar = create_test_rar()
+
+    # Realizar la conversión
+    test_zip = test_rar.replace(".rar", ".zip")
+    convert_rar_to_zip_file(test_rar, test_zip)
+
+    # Verificar contenido
+    with zipfile.ZipFile(test_rar, "r") as orig, zipfile.ZipFile(test_zip, "r") as conv:
+        assert sorted(orig.namelist()) == sorted(conv.namelist())
+
+    # Limpiar archivos temporales
+    os.unlink(test_rar)
+    os.unlink(test_zip)
 
 if __name__ == "__main__":
     test_conversion()


### PR DESCRIPTION
## Resumen
- Añade rutina `convert_rar_to_zip_file` que copia archivos y directorios sin perder entradas.
- Reemplaza la lógica del GUI para usar la nueva rutina y actualizar la barra de progreso.
- Amplía la prueba de conversión para incluir directorios vacíos y verificar que todos los elementos se conserven.

## Pruebas
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a88fc554408324992d3d3ee6b3384f